### PR TITLE
Adopt new tree UI

### DIFF
--- a/src/themes/dark.ts
+++ b/src/themes/dark.ts
@@ -129,7 +129,7 @@ export function create(palette: VscodePalette): VscodeTheme {
 			'list.errorForeground': p.colors.red,
 			'list.highlightForeground': p.colors.green,
 			'list.inactiveSelectionBackground': p.list.inactiveSelection.bg,
-			'list.focusBackground': p.list.focus.bg,
+			'quickInput.list.focusBackground': p.list.focus.bg,
 			'list.focusForeground': p.list.focus.fg,
 			'list.hoverBackground': p.list.hover.bg,
 			'list.warningForeground': p.colors.orange,

--- a/src/types/vscode-theme.ts
+++ b/src/types/vscode-theme.ts
@@ -134,7 +134,7 @@ export interface VscodeTheme {
 		'list.errorForeground': ThemeValue;
 		'list.highlightForeground': ThemeValue;
 		'list.inactiveSelectionBackground': ThemeValue;
-		'list.focusBackground': ThemeValue;
+		'quickInput.list.focusBackground': ThemeValue;
 		'list.focusForeground': ThemeValue;
 		'list.hoverBackground': ThemeValue;
 		'list.warningForeground': ThemeValue;


### PR DESCRIPTION
https://code.visualstudio.com/updates/v1_54#_updated-listtree-ui

> Breaking change

> Theme publishers are advised to adopt this style as well simply by swapping the customization of the `list.focusBackground` color for the `quickInput.list.focusBackground` color. To see an example, check out this [commit](https://github.com/microsoft/vscode/commit/4a941b1853a7b9e0173fd3f9c6eeeb6af13503f0#diff-f264602aa6d3cb74d6e344ffe88192b001c1611314325bad2b4f2cfa58b62031).